### PR TITLE
Fixed bug when the y-axis column is decimal

### DIFF
--- a/src/visualizers/highcharts/charts/chart.ts
+++ b/src/visualizers/highcharts/charts/chart.ts
@@ -4,7 +4,8 @@
 
 import * as _ from 'lodash';
 import * as Highcharts from 'highcharts';
-import { TooltipHelper } from '../tooltipHelper';
+import { TooltipHelper } from '../common/tooltipHelper';
+import { Utilities as HC_Utilities } from '../common/utilities';
 import { IVisualizerOptions } from '../../IVisualizerOptions';
 import { Utilities } from '../../../common/utilities';
 import { IColumn, IChartOptions, IRowValue } from '../../../common/chartModels';
@@ -60,7 +61,7 @@ export abstract class Chart {
 
             _.forEach(yAxesIndexes, (yAxisIndex, i) => {
                 const yAxisColumnName = chartOptions.columnsSelection.yAxes[i].name;
-                const yAxisValue = row[yAxisIndex];
+                const yAxisValue = HC_Utilities.getYValue(options.queryResultData.columns, row, yAxisIndex);
                 
                 if(!seriesMap[yAxisColumnName]) {
                     seriesMap[yAxisColumnName] = [];
@@ -105,7 +106,7 @@ export abstract class Chart {
 
         options.queryResultData.rows.forEach((row) => {
         	const xValue = row[xAxisColumnIndex];
-        	const yValue = row[yAxisColumnIndex];
+        	const yValue = HC_Utilities.getYValue(options.queryResultData.columns, row, yAxisColumnIndex);
         	const splitByValue = row[splitByColumnIndex];
         
         	if(!uniqueXValues[xValue]) {
@@ -164,7 +165,7 @@ export abstract class Chart {
             // X axis
             const xAxisColumn = chartOptions.columnsSelection.xAxis;
             const xColumnTitle = chartOptions.xAxisTitleFormatter ? chartOptions.xAxisTitleFormatter(xAxisColumn) : undefined;
-            let tooltip = TooltipHelper.getSingleTooltip(chartOptions, context, xAxisColumn, this.x, xColumnTitle);
+            let tooltip = TooltipHelper.getSingleTooltip(chartOptions, context, xAxisColumn, context.x, xColumnTitle);
 
             // Y axis
             const yAxes = chartOptions.columnsSelection.yAxes;
@@ -180,13 +181,13 @@ export abstract class Chart {
                 yColumn = yAxes[yColumnIndex];
             }
 
-            tooltip += TooltipHelper.getSingleTooltip(chartOptions, context, yColumn, this.y);
+            tooltip += TooltipHelper.getSingleTooltip(chartOptions, context, yColumn, context.y);
             
             // Split by
             const splitBy = chartOptions.columnsSelection.splitBy;
 
             if(splitBy && splitBy.length > 0) {
-                tooltip += TooltipHelper.getSingleTooltip(chartOptions, context, splitBy[0], this.series.name);
+                tooltip += TooltipHelper.getSingleTooltip(chartOptions, context, splitBy[0], context.series.name);
             }
             
             return '<table>' + tooltip + '</table>';
@@ -222,7 +223,7 @@ export abstract class Chart {
 
         options.queryResultData.rows.forEach((row) => {
             const splitByValue: string = <string>row[splitByColumnIndex];
-            const yValue = row[yAxisColumnIndex];
+            const yValue = HC_Utilities.getYValue(options.queryResultData.columns, row, yAxisColumnIndex);
             let xValue = row[xAxisColumnIndex];
 
             // For date the a-axis, convert its value to ms as this is what expected by Highcharts

--- a/src/visualizers/highcharts/charts/chart.ts
+++ b/src/visualizers/highcharts/charts/chart.ts
@@ -5,7 +5,7 @@
 import * as _ from 'lodash';
 import * as Highcharts from 'highcharts';
 import { TooltipHelper } from '../common/tooltipHelper';
-import { Utilities as HC_Utilities } from '../common/utilities';
+import { HC_Utilities } from '../common/utilities';
 import { IVisualizerOptions } from '../../IVisualizerOptions';
 import { Utilities } from '../../../common/utilities';
 import { IColumn, IChartOptions, IRowValue } from '../../../common/chartModels';

--- a/src/visualizers/highcharts/charts/pie.ts
+++ b/src/visualizers/highcharts/charts/pie.ts
@@ -1,8 +1,9 @@
 'use strict';
 
 import * as _ from 'lodash';
+import { Utilities as HC_Utilities } from '../common/utilities';
 import { Chart, ICategoriesAndSeries } from './chart';
-import { TooltipHelper } from '../tooltipHelper';
+import { TooltipHelper } from '../common/tooltipHelper';
 import { IVisualizerOptions } from '../../IVisualizerOptions';
 import { Utilities } from '../../../common/utilities';
 import { IColumn, IChartOptions } from '../../../common/chartModels';
@@ -49,11 +50,11 @@ export class Pie extends Chart {
 
         options.queryResultData.rows.forEach((row) => {
             const xAxisValue = <string>row[xAxisColumnIndex];
-            const yAxisValue = <number>row[yAxisColumnIndex];
+            const yAxisValue = HC_Utilities.getYValue(options.queryResultData.columns, row, yAxisColumnIndex);
 
             pieSeries.data.push({
                 name: xAxisValue,
-                y: yAxisValue 
+                y: yAxisValue
             })
         });
 
@@ -74,7 +75,7 @@ export class Pie extends Chart {
         let pieLevelData = pieData;
 
         options.queryResultData.rows.forEach((row) => {
-            const yAxisValue = row[yAxisColumnIndex];
+            const yAxisValue = HC_Utilities.getYValue(options.queryResultData.columns, row, yAxisColumnIndex);
 
             keyIndexes.forEach((keyIndex) => {  
                 const keyValue: string = <string>row[keyIndex];

--- a/src/visualizers/highcharts/charts/pie.ts
+++ b/src/visualizers/highcharts/charts/pie.ts
@@ -1,7 +1,7 @@
 'use strict';
 
 import * as _ from 'lodash';
-import { Utilities as HC_Utilities } from '../common/utilities';
+import { HC_Utilities } from '../common/utilities';
 import { Chart, ICategoriesAndSeries } from './chart';
 import { TooltipHelper } from '../common/tooltipHelper';
 import { IVisualizerOptions } from '../../IVisualizerOptions';

--- a/src/visualizers/highcharts/common/tooltipHelper.ts
+++ b/src/visualizers/highcharts/common/tooltipHelper.ts
@@ -1,7 +1,7 @@
 'use strict';
 
-import { DraftColumnType, DateFormat, IColumn, IChartOptions } from "../../common/chartModels";
-import { Utilities } from "../../common/utilities";
+import { DraftColumnType, DateFormat, IColumn, IChartOptions } from "../../../common/chartModels";
+import { Utilities } from "../../../common/utilities";
 
 export class TooltipHelper {
     public static getSingleTooltip(chartOptions: IChartOptions, context: Highcharts.TooltipFormatterContextObject, column: IColumn, originalValue: any, columnName?: string, valueSuffix: string = ''): string {

--- a/src/visualizers/highcharts/common/utilities.ts
+++ b/src/visualizers/highcharts/common/utilities.ts
@@ -7,10 +7,17 @@ export class HC_Utilities {
         const originalValue = row[yAxisIndex];
         const column = columns[yAxisIndex];
 
-        if(column.type === DraftColumnType.Decimal && typeof originalValue === 'string') {
-            return parseFloat(originalValue); // Highcharts support only numeric y-axis data
-        }
+        // Highcharts support only numeric y-axis data - if the y-axis isn't a number (can be a string that represents a number "0.005" for example) - convert it to number
+        if(typeof originalValue === 'string') {
+            if(column.type === DraftColumnType.Decimal) {
+                return parseFloat(originalValue);
+            } else if (column.type === DraftColumnType.Int) {
+                return parseInt(originalValue);
+            }
 
-        return <any>originalValue;
+            return Number(originalValue);
+        }
+        
+        return originalValue;  
     }
 }

--- a/src/visualizers/highcharts/common/utilities.ts
+++ b/src/visualizers/highcharts/common/utilities.ts
@@ -1,8 +1,8 @@
 'use strict';
 
-import { IQueryResultData, DraftColumnType, IColumn, IRow } from "../../../common/chartModels";
+import { DraftColumnType, IColumn, IRow } from "../../../common/chartModels";
 
-export class Utilities {
+export class HC_Utilities {
     public static getYValue(columns: IColumn[], row: IRow, yAxisIndex: number): number {
         const originalValue = row[yAxisIndex];
         const column = columns[yAxisIndex];

--- a/src/visualizers/highcharts/common/utilities.ts
+++ b/src/visualizers/highcharts/common/utilities.ts
@@ -1,0 +1,16 @@
+'use strict';
+
+import { IQueryResultData, DraftColumnType, IColumn, IRow } from "../../../common/chartModels";
+
+export class Utilities {
+    public static getYValue(columns: IColumn[], row: IRow, yAxisIndex: number): number {
+        const originalValue = row[yAxisIndex];
+        const column = columns[yAxisIndex];
+
+        if(column.type === DraftColumnType.Decimal && typeof originalValue === 'string') {
+            return parseFloat(originalValue); // Highcharts support only numeric y-axis data
+        }
+
+        return <any>originalValue;
+    }
+}

--- a/src/visualizers/highcharts/common/utilities.ts
+++ b/src/visualizers/highcharts/common/utilities.ts
@@ -7,7 +7,7 @@ export class HC_Utilities {
         const originalValue = row[yAxisIndex];
         const column = columns[yAxisIndex];
 
-        // Highcharts support only numeric y-axis data - if the y-axis isn't a number (can be a string that represents a number "0.005" for example) - convert it to number
+        // Highcharts support only numeric y-axis data. If the y-axis isn't a number (can be a string that represents a number "0.005" for example) - convert it to number
         if(typeof originalValue === 'string') {
             if(column.type === DraftColumnType.Decimal) {
                 return parseFloat(originalValue);

--- a/src/visualizers/highcharts/highchartsVisualizer.ts
+++ b/src/visualizers/highcharts/highchartsVisualizer.ts
@@ -249,6 +249,7 @@ export class HighchartsVisualizer implements IVisualizer {
                 const dataPoint = this;
                 const value = dataPoint.value;
 
+                // Ignore cases where the values is undefined / null / NaN etc.
                 if (typeof value === 'number') {
                     return chartOptions.numberFormatter(value);
                 } else {

--- a/src/visualizers/highcharts/highchartsVisualizer.ts
+++ b/src/visualizers/highcharts/highchartsVisualizer.ts
@@ -247,8 +247,13 @@ export class HighchartsVisualizer implements IVisualizer {
         if(chartOptions.numberFormatter && Utilities.isNumeric(column.type)) {
             formatter = function() {
                 const dataPoint = this;
+                const value = dataPoint.value;
 
-                return chartOptions.numberFormatter(dataPoint.value);
+                if (typeof value === 'number') {
+                    return chartOptions.numberFormatter(value);
+                } else {
+                    return value;
+                }         
             }
         } else if(chartOptions.dateFormatter && Utilities.isDate(column.type)) {
             formatter = function() {

--- a/src/visualizers/highcharts/highchartsVisualizer.ts
+++ b/src/visualizers/highcharts/highchartsVisualizer.ts
@@ -249,7 +249,7 @@ export class HighchartsVisualizer implements IVisualizer {
                 const dataPoint = this;
                 const value = dataPoint.value;
 
-                // Ignore cases where the values is undefined / null / NaN etc.
+                // Ignore cases where the value is undefined / null / NaN etc.
                 if (typeof value === 'number') {
                     return chartOptions.numberFormatter(value);
                 } else {

--- a/test/highcharts/chart.test.ts
+++ b/test/highcharts/chart.test.ts
@@ -463,9 +463,8 @@ describe('Unit tests for Chart methods', () => {
             // Assert
             expect(result).toEqual(expected);
         });
-
-        
-        it('Validate getSplitByCategoriesAndSeries for Line chart: non-date x-axis with splitB and decimal y-axis', () => {
+     
+        it('Validate getSplitByCategoriesAndSeries for Line chart: non-date x-axis with splitBy and decimal y-axis', () => {
             const rows = [
                 ['United States', 'Atlanta', "300.474"],
                 ['United States', 'Redmond', "20.2"]

--- a/test/highcharts/chart.test.ts
+++ b/test/highcharts/chart.test.ts
@@ -116,15 +116,15 @@ describe('Unit tests for Chart methods', () => {
 
         it('Validate getStandardCategoriesAndSeries for Line chart: non-date x-axis and multiple y-axis', () => {
             const rows = [
-                ['Israel', 'Herzliya', 30, 300],
-                ['United States', 'New York', 100, 150],
-                ['Japan', 'Tokyo', 20, 200],
+                ['Israel', 'Herzliya', "30", 300],
+                ['United States', 'New York', "100", 150],
+                ['Japan', 'Tokyo', "20.58305", 200],
             ];
 
             const columns: IColumn[] = [
                 { name: 'country', type: DraftColumnType.String },
                 { name: 'city', type: DraftColumnType.String },
-                { name: 'request_count', type: DraftColumnType.Int },
+                { name: 'request_count', type: DraftColumnType.Decimal },
                 { name: 'second_count', type: DraftColumnType.Int },
             ];
 
@@ -150,7 +150,7 @@ describe('Unit tests for Chart methods', () => {
             const expected: ICategoriesAndSeries = {
                 series: [{
                     name: 'request_count',
-                    data: [30, 100, 20]
+                    data: [30, 100, 20.58305]
                 },
                 {
                     name: 'second_count',
@@ -205,6 +205,96 @@ describe('Unit tests for Chart methods', () => {
                 {
                     name: 'second_count',
                     data: [[2019,  300], [2019, 150], [2000, 200]]
+                }],
+                categories: undefined
+            };
+
+            // Assert
+            expect(result).toEqual(expected);
+        });
+
+        it('Validate getStandardCategoriesAndSeries for Line chart with decimal y-axis', () => {
+            const rows = [
+                ['Israel', "252.3640552995391705069124423963134"],
+                ['United States', "100"],
+                ['Japan', "0.274074"],
+                ['China', "-5.274074"],
+                ['Ukraine', "976.5"],
+            ];
+
+            const columns: IColumn[] = [
+                { name: 'country', type: DraftColumnType.String },
+                { name: 'count', type: DraftColumnType.Decimal },
+            ];
+
+            // Input
+            const options: any = {
+                chartOptions: {
+                    columnsSelection: {
+                        xAxis: columns[0],  // country
+                        yAxes: [columns[1]] // count
+                    },
+                    utcOffset: 0
+                },
+                queryResultData: {
+                    rows: rows,
+                    columns: columns
+                }
+            }
+
+            // Act
+            const chart = ChartFactory.create(ChartType.Line);
+            const result: any = chart.getStandardCategoriesAndSeries(options);
+
+            const expected: ICategoriesAndSeries = {
+                series: [{
+                    name: 'count',
+                    data: [252.3640552995391705069124423963134, 100, 0.274074, -5.274074, 976.5]
+                }],
+                categories: ['Israel', 'United States', 'Japan', 'China', 'Ukraine']
+            };
+
+            // Assert
+            expect(result).toEqual(expected);
+        });
+     
+        it('Validate getStandardCategoriesAndSeries for Line chart: date x-axis and decimal y-axis', () => {
+            const rows = [
+                ['Israel', '2019-05-25T00:00:00Z', 'Herzliya', "252.36"],
+                ['Japan', '2019-05-25T00:00:00Z', 'Tokyo', "-5.5"],
+                ['United States', '2000-06-26T00:00:00Z', 'New York', "250"],
+            ];
+
+            const columns: IColumn[] = [
+                { name: 'country', type: DraftColumnType.String },
+                { name: 'timestamp', type: DraftColumnType.DateTime },
+                { name: 'city', type: DraftColumnType.String },
+                { name: 'request_count', type: DraftColumnType.Decimal },
+            ];
+
+            // Input
+            const options: any = {
+                chartOptions: {
+                    columnsSelection: {
+                        xAxis: columns[1],  // timestamp
+                        yAxes: [columns[3]] // request_count
+                    },
+                    utcOffset: 0
+                },
+                queryResultData: {
+                    rows: rows,
+                    columns: columns
+                }
+            }
+
+            // Act
+            const chart = ChartFactory.create(ChartType.Line);
+            const result: any = chart.getStandardCategoriesAndSeries(options);
+
+            const expected: ICategoriesAndSeries = {
+                series: [{
+                    name: 'request_count',
+                    data: [[2019,  252.36], [2019, -5.5], [2000, 250]]
                 }],
                 categories: undefined
             };
@@ -374,6 +464,55 @@ describe('Unit tests for Chart methods', () => {
             expect(result).toEqual(expected);
         });
 
+        
+        it('Validate getSplitByCategoriesAndSeries for Line chart: non-date x-axis with splitB and decimal y-axis', () => {
+            const rows = [
+                ['United States', 'Atlanta', "300.474"],
+                ['United States', 'Redmond', "20.2"]
+            ];
+
+            const columns: IColumn[] = [
+                { name: 'country', type: DraftColumnType.String },
+                { name: 'city', type: DraftColumnType.String },
+                { name: 'request_count', type: DraftColumnType.Decimal },
+            ];
+
+            // Input
+            const options: any = {
+                chartOptions: {
+                    columnsSelection: {
+                        xAxis: columns[0],    // country
+                        yAxes: [columns[2]],  // request_count
+                        splitBy: [columns[1]] // city
+                    },
+                    utcOffset: 0
+                },
+                queryResultData: {
+                    rows: rows,
+                    columns: columns
+                }
+            }
+
+            // Act
+            const chart = ChartFactory.create(ChartType.Line);
+            const result: any = chart.getSplitByCategoriesAndSeries(options);
+
+            const expected: ICategoriesAndSeries = {
+                series: [{
+                    name: 'Atlanta',
+                    data: [300.474]
+                },
+                {
+                    name: 'Redmond',
+                    data: [20.2]
+                }],
+                categories: ['United States']
+            };
+
+            // Assert
+            expect(result).toEqual(expected);
+        });
+
         //#endregion Line chart getSplitByCategoriesAndSeries
         
         //#region Pie chart getStandardCategoriesAndSeries
@@ -425,6 +564,55 @@ describe('Unit tests for Chart methods', () => {
                         { name: 'Herzliya', y: 30 },
                         { name: 'Jaffa', y: 50 },
                         { name: 'Boston', y: 1 }
+                    ]
+                }],
+                categories: undefined
+            };
+        
+            // Assert
+            expect(result.series).toEqual(expected.series);
+            expect(result.categories).toEqual(expected.categories);
+        });
+                
+        it('Validate getStandardCategoriesAndSeries for Pie chart with decimal y-axis', () => {
+            const rows = [
+                ['Israel', 'Tel Aviv', "0.003310"],
+                ['United States', 'Redmond', "0286"],
+                ['United States', 'New York', "3.144"]
+            ];
+        
+            const columns: IColumn[] = [
+                { name: 'country', type: DraftColumnType.String },
+                { name: 'city', type: DraftColumnType.String },
+                { name: 'request_count', type: DraftColumnType.Decimal },
+            ];
+        
+            // Input
+            const options: any = {
+                chartOptions: {
+                    columnsSelection: {
+                        xAxis: columns[1],    // city
+                        yAxes: [columns[2]],  // request_count
+                    },
+                    utcOffset: 0
+                },
+                queryResultData: {
+                    rows: rows,
+                    columns: columns
+                }
+            }
+        
+            // Act
+            const chart = ChartFactory.create(ChartType.Pie);
+            const result: any = chart.getStandardCategoriesAndSeries(options);
+
+            const expected: ICategoriesAndSeries = {
+                series: [{
+                    name: 'request_count',
+                    data: [
+                        { name: 'Tel Aviv', y: 0.003310 },
+                        { name: 'Redmond', y: 286 },
+                        { name: 'New York', y: 3.144 }
                     ]
                 }],
                 categories: undefined


### PR DESCRIPTION
Code flow:
http://codeflow/extensions/launcher.html?server=https:%2f%2fmseng.visualstudio.com%2f&projectId=96a62c4a-58c2-4dbb-94b6-5979ebc7f2af&reviewId=530822&projectshortname=AppInsights

Repro:
customEvents
| where name == "CustomerQuery"
| summarize Duration = avg(todecimal(customMeasurements["QueryLength"])) by bin(timestamp, 1d)
| render barchart title="Average Scan Duration (in seconds)"

https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2F4b3bd59a-46ba-42c2-9a9b-4c6cebcd00d4%2FresourceGroups%2Fmonitoring_group%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2FAIAnalyticsPortal-INT/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA0WOsQrCQBBEe8F%252FWK5KwMYPuELUTguxFIvNZUgOvI3s7UUifrwmjfW8eTOhZBvScYRYXq8%252B9OqhIOEE8p7cfomhlwKd3AzkkhJrfIMORdniIOSJx66yoUWIiR9VWEpncC6KNJtvbhGcIJ317l7X1EzURKksJmTj9NzQtq1nv0JaKDWsoWc1smgPeLcbodyBroHlv1xFoYwwSJvr37svpXm8qM0AAAA%253D/timespan/P1D