### PR TITLE
Formatted chart labels - added tooltip and truncate if the value is too long

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adx-query-charts",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "Draw charts from Azure Data Explorer queries",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/visualizers/highcharts/highchartsVisualizer.ts
+++ b/src/visualizers/highcharts/highchartsVisualizer.ts
@@ -256,15 +256,7 @@ export class HighchartsVisualizer implements IVisualizer {
                 formattedValue = chartOptions.dateFormatter(dataPoint.value, dateFormat);
             }
             
-            // If the label value greater than the max size, truncate it
-            const maxLabelLength: number = 100;
-            let truncatedValue = formattedValue;
-
-            if (formattedValue.length > maxLabelLength) {
-                truncatedValue = value.slice(0, maxLabelLength) + '...';              
-            }
-        
-            return `<span title="${formattedValue}">${truncatedValue}</span>`;
+            return `<span title="${formattedValue}">${formattedValue}</span>`;
         }
 
         return {


### PR DESCRIPTION
Handle axis labels:
1. Added tooltips for all the labels:
![image](https://user-images.githubusercontent.com/17854021/84998583-b202fc80-b158-11ea-9067-47d5862042c7.png)

2. Added nowrap to handle tooltips with line break
3. Truncate labels if they are too long

Before:
![image](https://user-images.githubusercontent.com/17854021/84998732-e4acf500-b158-11ea-9cb7-59083d4b5912.png)

After:
![image](https://user-images.githubusercontent.com/17854021/84998770-f0002080-b158-11ea-887b-e90c90683d88.png)

![image](https://user-images.githubusercontent.com/17854021/84998792-f9898880-b158-11ea-9a27-cc286ebeb90e.png)


Repro:
https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2F4b3bd59a-46ba-42c2-9a9b-4c6cebcd00d4%2FresourceGroups%2Fmonitoring_group%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2FAIAnalyticsPortal-INT/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA02OsQqDMBiEd5%252FiNlsopOAshW7dhY4lJkdj0ST8%252FsUKffgqdXA6uLuPO2PQpIwKraRppIAfx6xdimNhDO7BKiYKoYEI3TNwVAhzEqXflaHJ2%252FlS7PAvprCSMSmHrPPB9R2jPq7%252FpSNs9Ni8Zs5EXaPcwnKhs6QXna7a9hxu%252FoTqvPjC6JejLvXvIbpgRVH8AIHAsGLHAAAA/timespan/P1D

Code flow:
http://codeflow/extensions/launcher.html?server=https:%2f%2fmseng.visualstudio.com%2f&projectId=96a62c4a-58c2-4dbb-94b6-5979ebc7f2af&reviewId=557624&projectshortname=AppInsights
