### PR TITLE
Fixed 'FAILED TO CREATE VISUALIZATION' error when one of the y values in a non split-by chart is undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adx-query-charts",
-  "version": "1.1.28",
+  "version": "1.1.29",
   "description": "Draw charts from Azure Data Explorer queries",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/visualizers/highcharts/common/utilities.ts
+++ b/src/visualizers/highcharts/common/utilities.ts
@@ -4,7 +4,7 @@ import { DraftColumnType, IColumn, IRow } from "../../../common/chartModels";
 
 export class HC_Utilities {
     public static getYValue(columns: IColumn[], row: IRow, yAxisIndex: number): number {
-        const originalValue = row[yAxisIndex];
+        const originalValue = row[yAxisIndex] || null; // If the y value is undefined - convert to null since Highcharts don't support numeric undefined values
         const column = columns[yAxisIndex];
 
         // Highcharts support only numeric y-axis data. If the y-axis isn't a number (can be a string that represents a number "0.005" for example) - convert it to number


### PR DESCRIPTION
Fixed 'FAILED TO CREATE VISUALIZATION' error when one of the y values in a non split-by chart is undefined.
Repro:
1. Run query:
https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2F4b3bd59a-46ba-42c2-9a9b-4c6cebcd00d4%2FresourceGroups%2Fmonitoring_group%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2FAIAnalyticsPortal-INT/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA32QPW8CMQyGdyT%252Bg8V0J53YGBhuo0MHEFNXFHJuSXWxI8e5AuqPbxJuoEM7v8%252F7YdsUlf3LhKRxufiGrwsKAhmP0PewOqK8s3hDFvdoYhJcFQqvijTAIWMn6EE5qjj6aGxN2zmPFB1TXBeifXLskhjNyivt48M5cDqPODvnDl%252FWrJ%252FZmhGT90bcHcFyIm3aDo7bTU4JKDZbXM75VdDBdtPC%252BQYmhNHZKpzeUMq27rG%252B5AbhT7T6D1WL6hmTGZNRhOAm1mYWvbk2GWjrSpYB5Y%252FSokv%252BQwYsj8mTvRhRgOXiBxAXolOIAQAA/timespan/P1D

2. Click on "Select all" in the y-axes selection

Before:
![image](https://user-images.githubusercontent.com/17854021/85221464-a1eb5700-b3bc-11ea-847b-abc4d5db7bbf.png)

After:
![image](https://user-images.githubusercontent.com/17854021/85221473-b596bd80-b3bc-11ea-8594-7ec6c0a396c7.png)


Code flow:
http://codeflow/extensions/launcher.html?server=https:%2f%2fmseng.visualstudio.com%2f&projectId=96a62c4a-58c2-4dbb-94b6-5979ebc7f2af&reviewId=558089&projectshortname=AppInsights