### PR TITLE
Align charts color palette with Azure colors

### DIFF
--- a/src/visualizers/highcharts/themes/darkTheme.ts
+++ b/src/visualizers/highcharts/themes/darkTheme.ts
@@ -9,7 +9,7 @@ const hiddenStyleColor: string = '#606063';
 const strokeColor: string = '000000';
 
 export const DarkThemeOptions: Highcharts.Options = {
-    colors: ['#2b908f', '#90ee7e', '#f45b5b', '#7798BF', '#aaeeee', '#ff0066', '#eeaaee', '#55BF3B', '#DF5353', '#7798BF', '#aaeeee'],
+    colors: ['#0078D4', '#CB4936', '#BEDFFF', '#038387', '#F6C0FF', '#D90086', '#A4E1D2', '#6E5DB7', '#C7D3FF', '#FFCA8A'],
     chart: {
         backgroundColor: '#111111',
     },

--- a/src/visualizers/highcharts/themes/lightTheme.ts
+++ b/src/visualizers/highcharts/themes/lightTheme.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 export const LightThemeOptions: Highcharts.Options = {
+    colors: ['#0078D4', '#EF6950', '#00188F', '#00A2AD', '#4B003F', '#E3008C', '#022F22', '#917EDB', '#001D3F', '#502006'],
     tooltip: {
         backgroundColor: 'rgba(255, 255, 255, 0.85)'
     },


### PR DESCRIPTION
Align charts color palette with Azure colors

Figma: 
https://www.figma.com/file/qw3WdFx7llXGCzKbCiokYF/LA-Ongoing-Tasks?node-id=1105%3A18

Before:
![image](https://user-images.githubusercontent.com/17854021/85941123-9bfbf580-b929-11ea-9a2f-ea75e48be044.png)

After:
![image](https://user-images.githubusercontent.com/17854021/85941131-a1f1d680-b929-11ea-9728-b451fc6a05cb.png)
