### PR TITLE
Changed areColumnsEqual logic - if both of the columns are with the s…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adx-query-charts",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "description": "Draw charts from Azure Data Explorer queries",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/common/kustoChartHelper.ts
+++ b/src/common/kustoChartHelper.ts
@@ -419,11 +419,12 @@ ${this.getColumnsStr(queryResultData.columns)}`;
             }
 
             indexes.push(indexOfColumn);
+            const originalColumn = queryResultData.columns[indexOfColumn];
 
             // Add each column name and type to the chartColumns
             chartColumns.push({
-                name: <string>LimitVisResultsSingleton.escapeStr(column.name),
-                type: column.type
+                name: <string>LimitVisResultsSingleton.escapeStr(originalColumn.name),
+                type: originalColumn.type
             });
         }
 

--- a/src/common/utilities.ts
+++ b/src/common/utilities.ts
@@ -54,7 +54,14 @@ export class Utilities {
     }
 
     public static areColumnsEqual(first: IColumn, second: IColumn): boolean {
-        return first.name == second.name && first.type == second.type;
+        let columnsEqual: boolean = first.name == second.name;
+
+        // Check type equality
+        if(columnsEqual) {
+            columnsEqual = first.type == second.type || (Utilities.isNumeric(first.type) && Utilities.isNumeric(second.type));
+        }
+
+        return columnsEqual;
     }
 
     public static isPieOrDonut(chartType: ChartType): boolean {

--- a/test/kustoChartHelper.test.ts
+++ b/test/kustoChartHelper.test.ts
@@ -253,6 +253,53 @@ describe('Unit tests for KustoChartHelper', () => {
             expect(result).toEqual(expected);
         });
 
+        it("When the columns selection and query results both numeric, but different types - the input is valid, the query result transformed as expected", () => {
+            // Input
+            const queryResultData = {
+                rows: [
+                    ['Israel', '2000-05-24T00:00:00Z', 100, 10],
+                    ['United States', '2000-05-25T00:00:00Z', 80, 8],
+                    ['Japan', '2019-05-26T00:00:00Z', 20, 2]
+                ],
+                columns: [
+                    { name: 'country', type: DraftColumnType.String },
+                    { name: 'date', type: DraftColumnType.DateTime },
+                    { name: 'request_count', type: DraftColumnType.Int },
+                    { name: 'second_count', type: DraftColumnType.Real },     
+                ]
+            };
+
+            const chartOptions = {
+                columnsSelection: {
+                    xAxis: queryResultData.columns[1],
+                    yAxes: [{ name: 'request_count', type: DraftColumnType.Decimal }, { name: 'second_count', type: DraftColumnType.Long }]
+                }
+            };
+
+            // Act
+            const result = kustoChartHelper['transformQueryResultData'](queryResultData, <any>chartOptions);
+            const aggregatedRows = [
+                ['2000-05-24T00:00:00Z', 100, 10],
+                ['2000-05-25T00:00:00Z', 80, 8],
+                ['2019-05-26T00:00:00Z', 20, 2]
+            ];
+
+            const expected = {
+                data: {
+                    rows: aggregatedRows,
+                    columns: [queryResultData.columns[1], queryResultData.columns[2], queryResultData.columns[3]]
+                },
+                limitedResults: {
+                    rows: aggregatedRows,
+                    isAggregationApplied: false,
+                    isPartialData: false
+                }
+            };
+
+            // Assert
+            expect(result).toEqual(expected);
+        });
+
         it("When the x-axis columns selection input is invalid", () => {
             // Input
             const queryResultData = {


### PR DESCRIPTION
Changed areColumnsEqual logic:
If both of the columns are with the name, and the type is different. Check if both of the columns are numeric - if they are, the considered to be equal.

Code flow:
http://codeflow/extensions/launcher.html?server=https:%2f%2fmseng.visualstudio.com%2f&projectId=96a62c4a-58c2-4dbb-94b6-5979ebc7f2af&reviewId=560808&projectshortname=AppInsights