### PR TITLE
Fixed a bug when y-axis is zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adx-query-charts",
-  "version": "1.1.40",
+  "version": "1.1.41",
   "description": "Draw charts from Azure Data Explorer queries",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/visualizers/highcharts/common/utilities.ts
+++ b/src/visualizers/highcharts/common/utilities.ts
@@ -4,8 +4,13 @@ import { DraftColumnType, IColumn, IRow } from "../../../common/chartModels";
 
 export class HC_Utilities {
     public static getYValue(columns: IColumn[], row: IRow, yAxisIndex: number): number {
-        const originalValue = row[yAxisIndex] || null; // If the y value is undefined - convert to null since Highcharts don't support numeric undefined values
         const column = columns[yAxisIndex];
+        let originalValue = row[yAxisIndex]; 
+        
+        // If the y value is undefined - convert to null since Highcharts don't support numeric undefined values
+        if(originalValue === undefined) {
+            originalValue = null;
+        }
 
         // Highcharts support only numeric y-axis data. If the y-axis isn't a number (can be a string that represents a number "0.005" for example) - convert it to number
         if(typeof originalValue === 'string') {


### PR DESCRIPTION
Repro:
https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2F4b3bd59a-46ba-42c2-9a9b-4c6cebcd00d4%2FresourceGroups%2Fmonitoring_group%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2FAIAnalyticsPortal-INT/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA32RT2vDMAzF74V%252Bh0dPCWRtetopu4ydd9yxqI5Se4vt4j9tU%252Fbhp7iwFTYGxjaS3%252B9J8maDN80O0wNdTISsFkkzRuMYSlNIiNrnsYfyzrFKqCx9MGIOjMlnaDoxrhw8TjRmFoQrgBuwgRngfGpmljtwSWmmsGdKO%252BWzS3jCYyumHoTeDAMHlmCBLRcqx%252BTty0lCcbn4xFlLGslYjonsUbR08NW2r%252Bdk9FLtfrpLU1Q%252FKjUaweyeTZrQdVi9xtGvii5bS8Fcf1XWoZxVPVP3xlXf5AZbXTf3yBnEl8SuB41GZtJJ60P1V68iXsvWrtv%252Fyz4G%252Fz5P%252FM61oH%252F5ysR6DuXd7cvOJmlUk5W%252F6CBWk6WL3Lb14gspDXaX8AEAAA%253D%253D

Before:
![image](https://user-images.githubusercontent.com/17854021/86894212-703bf500-c10b-11ea-95b9-8471b1eee3be.png)

After:
![image](https://user-images.githubusercontent.com/17854021/86894246-792cc680-c10b-11ea-93a3-1d9afcbcc3ce.png)

