### PR TITLE
Always show pie percentage in the pie labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adx-query-charts",
-  "version": "1.1.48",
+  "version": "1.1.49",
   "description": "Draw charts from Azure Data Explorer queries",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/visualizers/highcharts/charts/pie.ts
+++ b/src/visualizers/highcharts/charts/pie.ts
@@ -36,7 +36,7 @@ export class Pie extends Chart {
                 showInLegend: true,
                 dataLabels: {
                     formatter: function() {
-                        return `${this.point.name}${self.getPercentageSuffix(this)}`;
+                        return `<b>${this.point.name}</b>${self.getPercentageSuffix(this)}`;
                     },
                     style: {
                         textOverflow: 'ellipsis'


### PR DESCRIPTION
Always show pie percentage in the pie labels (even when the labels are truncated)
Code flow: http://codeflow/extensions/launcher.html?server=https:%2f%2fmseng.visualstudio.com%2f&projectId=96a62c4a-58c2-4dbb-94b6-5979ebc7f2af&reviewId=570434&projectshortname=AppInsights

Before:
![image](https://user-images.githubusercontent.com/17854021/91836067-f3cd1a80-ec52-11ea-9162-ab513693af33.png)

After:
![image](https://user-images.githubusercontent.com/17854021/91836078-f760a180-ec52-11ea-8f16-43e97df5cfae.png)

![image](https://user-images.githubusercontent.com/17854021/91836102-fd568280-ec52-11ea-8e51-98a73cd715c2.png)
