### PR TITLE
Reduce chart's point symbol radius

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adx-query-charts",
-  "version": "1.1.49",
+  "version": "1.1.50",
   "description": "Draw charts from Azure Data Explorer queries",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/visualizers/highcharts/charts/chart.ts
+++ b/src/visualizers/highcharts/charts/chart.ts
@@ -27,6 +27,9 @@ export abstract class Chart {
             series: {
                 animation: {
                     duration: chartOptions.animationDurationMS
+                },
+                marker: {
+                    radius: 2 // The radius of chart's the point marker
                 }
             }
         }

--- a/src/visualizers/highcharts/charts/chart.ts
+++ b/src/visualizers/highcharts/charts/chart.ts
@@ -29,7 +29,7 @@ export abstract class Chart {
                     duration: chartOptions.animationDurationMS
                 },
                 marker: {
-                    radius: 2 // The radius of chart's the point marker
+                    radius: 2 // The radius of the chart's point marker
                 }
             }
         }


### PR DESCRIPTION
Code flow:
http://codeflow/extensions/launcher.html?server=https%3a%2f%2fmseng.visualstudio.com%2f&projectId=96a62c4a-58c2-4dbb-94b6-5979ebc7f2af&reviewId=575159&projectshortname=AppInsights

Reduced the chart's point symbol radius from 4 to 2.
Before:
![image](https://user-images.githubusercontent.com/17854021/94520227-8f42b280-0234-11eb-9be1-3f2e5fd33e7d.png)

After:
![image](https://user-images.githubusercontent.com/17854021/94520240-95389380-0234-11eb-89c9-14be8ba66dae.png)

See HC example:
https://jsfiddle.net/gh/get/library/pure/highcharts/highcharts/tree/master/samples/highcharts/plotoptions/series-marker-radius/