### PR TITLE
Remove redundant escaping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adx-query-charts",
-  "version": "1.1.57",
+  "version": "1.1.58",
   "description": "Draw charts from Azure Data Explorer queries",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/common/kustoChartHelper.ts
+++ b/src/common/kustoChartHelper.ts
@@ -101,9 +101,6 @@ export class KustoChartHelper implements IChartHelper {
                     this.chartInfo.dataTransformationInfo.isPartialData = transformed.limitedResults.isPartialData;
                 }
         
-                // Escape columns selection since the columns data is used in the tooltips
-                this.escapeColumnsSelection(chartOptions);         
-
                 const visualizerOptions: IVisualizerOptions = {
                     elementId: this.elementId,
                     queryResultData: this.transformedQueryResultData,
@@ -426,7 +423,7 @@ ${this.getColumnsStr(queryResultData.columns)}`;
             const originalColumn = queryResultData.columns[indexOfColumn];
 
             // Add each column name and type to the chartColumns
-            chartColumns.push(this.escapeColumnName(originalColumn));
+            chartColumns.push(originalColumn);
         }
 
         return notFoundColumns;
@@ -517,21 +514,6 @@ ${this.getColumnsStr(queryResultData.columns)}`;
         this.chartInfo.status = DrawChartStatus.Failed;
         this.chartInfo.error = error;
         this.finishDrawing(resolve, chartOptions);
-    }
-
-    private escapeColumnsSelection(chartOptions: IChartOptions): void {
-        chartOptions.columnsSelection = {
-            xAxis: chartOptions.columnsSelection.xAxis && this.escapeColumnName(chartOptions.columnsSelection.xAxis),
-            yAxes: chartOptions.columnsSelection.yAxes && chartOptions.columnsSelection.yAxes.map(y => this.escapeColumnName(y)),
-            splitBy: chartOptions.columnsSelection.splitBy && chartOptions.columnsSelection.splitBy.map(s => this.escapeColumnName(s))
-        };
-    }
-
-    private escapeColumnName(originalColumn: IColumn): IColumn {
-        return {
-            name: <string>Utilities.escapeStr(originalColumn.name),
-            type: originalColumn.type
-        };
     }
 
     //#endregion Private methods

--- a/src/visualizers/highcharts/charts/pie.ts
+++ b/src/visualizers/highcharts/charts/pie.ts
@@ -163,7 +163,6 @@ export class Pie extends Chart {
     }
 
     protected /*override*/ getDataPoint(chartOptions: IChartOptions, point: Highcharts.Point): IDataPoint {
-        const seriesColumnName: string = point.series.name; 
         const xColumn: IColumn = chartOptions.columnsSelection.xAxis;
         const splitBy = chartOptions.columnsSelection.splitBy;
         let seriesColumn: IColumn;
@@ -172,7 +171,7 @@ export class Pie extends Chart {
         if (splitBy && splitBy.length > 0) {
             // Find the current key column
             const keyColumnIndex = _.findIndex(splitBy, (col) => { 
-                return col.name === point.series.name 
+                return col.name === point.series.name; 
             });
 
             seriesColumn = splitBy[keyColumnIndex];

--- a/src/visualizers/highcharts/common/formatter.ts
+++ b/src/visualizers/highcharts/common/formatter.ts
@@ -8,6 +8,7 @@ import { Utilities } from "../../../common/utilities";
 export class Formatter {
     public static getSingleTooltip(chartOptions: IChartOptions, column: IColumn, originalValue: any, columnName?: string, valueSuffix: string = ''): string {
         const maxLabelWidth: number = 100;
+        let escapedColumnName = Utilities.escapeStr(columnName || column.name);
         let formattedValue = '';
         
         if(originalValue != undefined) {
@@ -19,7 +20,7 @@ export class Formatter {
             }
         }
 
-        return `<tr><td>${columnName || column.name}: </td><td><b>${formattedValue + valueSuffix}</b></td></tr>`;
+        return `<tr><td>${escapedColumnName}: </td><td><b>${formattedValue + valueSuffix}</b></td></tr>`;
     }
           
     public static getLabelsFormatter(chartOptions: IChartOptions, column: IColumn, useHTML: boolean): Highcharts.FormatterCallbackFunction<Highcharts.AxisLabelsFormatterContextObject<number>> {


### PR DESCRIPTION
The new HC version is escaping the content by default, except the tooltips (because we use our own HTML) - So all our custom escaping, except tooltip, is no longer needed.
Repro:
https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2F7948c75a-ee6e-4c34-b391-52ba5dca56dd%2Fresourcegroups%2Failoganalyticsportal-test2%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Faianalytics-test2/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA31QQU7DMBC8V8ofVr40RVUsJE4ozRPg0AsS5eA6W8dS4jXrTWgRj8cJQdy47EozszOj1RqeIwZocQIh6lMFxUZreDKTd0Ywg2A7w5L20NGEDNLhisycQ1mQ%252BVZ8rIBmt4Q9WiHObo4WGfu2ArxGE9pFz%252FSRSRS75mVnf7lBoCyyGMVTyImBGGgURz44YHwfMf3Eqk4kpketHZHrsbI06GtKlfMXVWzGkM%252Fhrth8QRqHwbD%252FzJ1pDFLu9vCqai1tkwfP40ztbd7m3GNTJ8s%252BSmNzPGXfnly5fTket7tar1TtBweJ7eH0T4mTatQbHED9GpoeWcr7hz8fNddjDG3%252BabJGBHl56zddZDETkgEAAA%253D%253D/timespan/P1D